### PR TITLE
fix: correct typo in prompt explanation for Claude & Gemini Clients

### DIFF
--- a/src/clients/claude_client.rs
+++ b/src/clients/claude_client.rs
@@ -79,7 +79,7 @@ impl AiProvider for ClaudeClient {
         let prompt = if let Some(custom_prompt) = &self.prompt {
             custom_prompt.clone()
         } else {
-            "Take the handwritten notes from this image and convert them into a clean, well-structured Markdown file. Pay attention to headings, lists, and any other formatting. Resemble the hierarchy. Use latex for mathematical equations. For latex use the $$ syntax instead of ```latex. Do not skip anything from the original text. The output should be suitable for use in Obsidian. Just give me the markdown, do not include other text in the response apart from the markdown file. No explanation on how the changes where made is needed".to_string()
+            "Take the handwritten notes from this image and convert them into a clean, well-structured Markdown file. Pay attention to headings, lists, and any other formatting. Resemble the hierarchy. Use latex for mathematical equations. For latex use the $$ syntax instead of ```latex. Do not skip anything from the original text. The output should be suitable for use in Obsidian. Just give me the markdown, do not include other text in the response apart from the markdown file. No explanation on how the changes were made is needed".to_string()
         };
 
         let request_body = ClaudeRequest {

--- a/src/clients/gemini_client.rs
+++ b/src/clients/gemini_client.rs
@@ -85,7 +85,7 @@ impl AiProvider for GeminiClient {
         let prompt = if let Some(custom_prompt) = &self.prompt {
             custom_prompt.clone()
         } else {
-            "Take the handwritten notes from this image and convert them into a clean, well-structured Markdown file. Pay attention to headings, lists, and any other formatting. Resemble the hierarchy. Use latex for mathematical equations. For latex use the $$ syntax instead of ```latex. Do not skip anything from the original text. The output should be suitable for use in Obsidian. Just give me the markdown, do not include other text in the response apart from the markdown file. No explanation on how the changes where made is needed".to_string()
+            "Take the handwritten notes from this image and convert them into a clean, well-structured Markdown file. Pay attention to headings, lists, and any other formatting. Resemble the hierarchy. Use latex for mathematical equations. For latex use the $$ syntax instead of ```latex. Do not skip anything from the original text. The output should be suitable for use in Obsidian. Just give me the markdown, do not include other text in the response apart from the markdown file. No explanation on how the changes were made is needed".to_string()
         };
 
         let request_body = GeminiRequest {


### PR DESCRIPTION
Changes "where" to "were" in prompts for Claude and Gemini clients.

fixes #2 