### PR TITLE
feat: Added `--show`, `--edit`, `--set-provider` options to `config` command and improved error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.2.3]
+
+### Added
+- Added `--show`, `--edit`, and `--set-provider` subcommands to the `config` command for better configuration management.
+
+### Changed
+- Updated the Claude model selection from a text input to a selection menu to improve user experience and prevent typos.
+
+### Fixed
+- Resolved an issue where API errors in successful (`200 OK`) responses were ignored, preventing silent failures.
+- Corrected a bug where configuring the Ollama provider would erase all other existing provider settings.
+
 ## [0.2.2]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "notedmd"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -833,6 +833,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "thiserror 2.0.12",
  "tokio",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedmd"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 description = "A command-line tool to convert handwritten notes into a clean and readable Markdown file."
 license = "MIT"
@@ -23,3 +23,4 @@ dialoguer = "0.11.0"
 colored = "3.0.0"
 indicatif = "0.17.11"
 async-trait = "0.1.88"
+thiserror = "2.0.12"

--- a/README.md
+++ b/README.md
@@ -60,69 +60,97 @@ cargo build --release
 # The executable will be in target/release/notedmd
 ```
 
-
 ## Usage
 
-### 1. Configuration
+The typical workflow is:
+1.  **Configure your AI provider**: Use `notedmd config --edit` for a guided setup.
+2.  **Convert your files**: Use `notedmd convert <path>` to process your notes.
 
-Run `notedmd config` to configure your AI provider. You can choose between:
-  - Gemini API **(recommended)**
-  - Claude API
-  - Ollama
+### Commands
+
+| Command           | Description                                                                          |
+| ----------------- | ------------------------------------------------------------------------------------ |
+| `notedmd convert` | Converts a file or all supported files in a directory into Markdown.                 |
+| `notedmd config`  | Manages the AI provider configuration. Shows the current config if no flags are used. |
+
+---
+
+## Configuration
+
+### Interactive Setup (Recommended)
+
+For first-time users, the interactive setup is the easiest way to get started. Run:
+```bash
+notedmd config --edit
+```
+This will guide you through selecting an AI provider (Gemini, Claude, or Ollama) and entering the necessary credentials, such as API keys or server details.
+
+### AI Providers
+
+You can choose between three AI providers.
 
 #### Gemini and Claude APIs
-You can get the API keys from their respective websites:
+You will need an API key from your chosen provider:
 - **Gemini API:** [Google AI Studio](https://aistudio.google.com/app/apikey)
 - **Claude API:** [Anthropic's website](https://console.anthropic.com/dashboard)
 
-During the initial `notedmd config` setup, you will be prompted for your key.
-
-If you wish to change the API key later, you can do so in two ways:
-
--   **Using the `config` command**:
-    - For Gemini:
-      ```bash
-      notedmd config --set-api-key YOUR_GEMINI_API_KEY
-      ```
-    - For Claude:
-      ```bash
-      notedmd config --set-claude-api-key YOUR_CLAUDE_API_KEY
-      ```
-
--   **Using the `--api-key` flag**:
-    This flag overrides the active provider's API key for a single `convert` command.
-    ```bash
-    notedmd convert my_file.pdf --api-key YOUR_API_KEY
-    ```
-
-
 #### Ollama
-Make sure Ollama is installed and running. You can download Ollama from [Ollama's website](https://ollama.com/).
+Make sure Ollama is installed and running on your local machine. You can download it from [Ollama's website](https://ollama.com/).
 
+### Managing Configuration via Flags
 
-You can see where the configuration is stored by running:
-```bash
-notedmd config --show-path
-```
+You can also manage your configuration directly using flags.
 
-### 2. Converting Files
+| Flag                             | Description                                                                 |
+| -------------------------------- | --------------------------------------------------------------------------- |
+| `--set-provider <provider>`      | Set the active provider (`gemini`, `claude`, `ollama`).                       |
+| `--set-api-key <key>`            | Set the API key for Gemini.                                                 |
+| `--set-claude-api-key <key>`     | Set the API key for Claude.                                                 |
+| `--show`                         | Display the current configuration.                                          |
+| `--show-path`                    | Show the absolute path to your configuration file.                          |
+| `--edit`                         | Start the interactive configuration wizard.                                 |
+
+**Examples:**
+- Set the active provider to Claude:
+  ```bash
+  notedmd config --set-provider claude
+  ```
+- Set your Gemini API key:
+  ```bash
+  notedmd config --set-api-key YOUR_GEMINI_API_KEY
+  ```
+
+---
+
+## Converting Files
+
+Once configured, you can convert your handwritten notes.
+
+| Flag                             | Description                                                                 |
+| -------------------------------- | --------------------------------------------------------------------------- |
+| `-o`, `--output <dir>`           | Specify a directory to save the converted Markdown file(s).                 |
+| `-p`, `--prompt <prompt>`        | Add a custom prompt to override the default instructions for the LLM.       |
+| `--api-key <key>`                | Temporarily override the stored API key for a single `convert` command.     |
+
+**Examples:**
 
 -   **Convert a single file**:
-
     The converted file will be saved in the same directory with a `.md` extension (e.g., `my_document.md`).
-
     ```bash
     notedmd convert my_document.pdf
     ```
 
--   **Convert a single file to a specific output directory**:
+-   **Convert a file with a custom prompt**:
+    ```bash
+    notedmd convert my_notes.png --prompt "Transcribe this into a bulleted list."
+    ```
 
+-   **Convert a file and save it to a different directory**:
     ```bash
     notedmd convert my_document.pdf --output ./markdown_notes/
     ```
 
 -   **Convert all supported files in a directory**:
-
     ```bash
     notedmd convert ./my_project_files/
     ```

--- a/src/ai_provider.rs
+++ b/src/ai_provider.rs
@@ -1,9 +1,7 @@
+use crate::{error::NotedError, file_utils::FileData};
 use async_trait::async_trait;
-
-use crate::file_utils::FileData;
 
 #[async_trait]
 pub trait AiProvider {
-    async fn send_request(&self, file_data: FileData)
-    -> Result<String, Box<dyn std::error::Error>>;
+    async fn send_request(&self, file_data: FileData) -> Result<String, NotedError>;
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -45,8 +45,20 @@ pub enum Commands {
         #[arg(long, help = "Set your Claude API key for future use")]
         set_claude_api_key: Option<String>,
 
+        // Set active provider
+        #[arg(long, help = "Set the active provider")]
+        set_provider: Option<String>,
+
         /// Show config file location
-        #[arg(long, help = "Display the path to your configuration file")]
+        #[arg(long, help = "Shows the location of your configuration file")]
         show_path: bool,
+
+        // Show config file
+        #[arg(long, help = "Shows the content of your configuration")]
+        show: bool,
+
+        // Trigger onboarding flow
+        #[arg(long, help = "Edit the configuration file")]
+        edit: bool,
     },
 }

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -1,4 +1,3 @@
-
 pub mod claude_client;
 pub mod gemini_client;
 pub mod ollama_client;

--- a/src/clients/ollama_client.rs
+++ b/src/clients/ollama_client.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
-use reqwest::Client;
+use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
 
-use crate::{ai_provider::AiProvider, file_utils::FileData};
+use crate::{ai_provider::AiProvider, error::NotedError, file_utils::FileData};
 
 // Request struct
 #[derive(Serialize)]
@@ -17,6 +17,8 @@ struct OllamaRequest {
 #[derive(Deserialize, Debug)]
 pub struct OllamaResponse {
     pub response: String,
+    #[serde(default)]
+    pub error: Option<String>,
 }
 
 // Client struct
@@ -40,10 +42,7 @@ impl OllamaClient {
 
 #[async_trait]
 impl AiProvider for OllamaClient {
-    async fn send_request(
-        &self,
-        file_data: FileData,
-    ) -> Result<String, Box<dyn std::error::Error>> {
+    async fn send_request(&self, file_data: FileData) -> Result<String, NotedError> {
         let url = format!("{}/api/generate", self.url);
         let prompt = if let Some(custom_prompt) = &self.prompt {
             custom_prompt.clone()
@@ -58,17 +57,33 @@ impl AiProvider for OllamaClient {
             stream: false,
         };
 
-        let response = self
-            .client
-            .post(&url)
-            .json(&request_body)
-            .send()
-            .await?
-            .json::<OllamaResponse>()
-            .await?;
+        let response = self.client.post(&url).json(&request_body).send().await?;
 
-        let response_text = response.response;
-        let cleaned_markdown = response_text
+        let status = response.status();
+        let response_body = response.text().await?;
+
+        if status != StatusCode::OK {
+            let error_response: Result<OllamaResponse, _> = serde_json::from_str(&response_body);
+            if let Ok(err_resp) = error_response {
+                if let Some(error) = err_resp.error {
+                    return Err(NotedError::ApiError(error));
+                }
+            }
+            return Err(NotedError::ApiError(format!(
+                "Received status code: {}",
+                status
+            )));
+        }
+
+        let ollama_response: OllamaResponse = serde_json::from_str(&response_body)
+            .map_err(|e| NotedError::ResponseDecodeError(e.to_string()))?;
+
+        if let Some(error) = ollama_response.error {
+            return Err(NotedError::ApiError(error));
+        }
+
+        let cleaned_markdown = ollama_response
+            .response
             .trim_start_matches("```markdown\n")
             .trim_end_matches("```");
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
-use std::{fs, path::PathBuf};
-
+use crate::error::NotedError;
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
+use std::{fs, path::PathBuf};
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct Config {
@@ -39,17 +39,17 @@ pub fn get_config_path() -> Option<PathBuf> {
 }
 
 impl Config {
-    pub fn load() -> Self {
+    pub fn load() -> Result<Self, NotedError> {
         if let Some(config_path) = get_config_path() {
             if config_path.exists() {
-                let content = fs::read_to_string(config_path).unwrap_or_default();
-                return toml::from_str(&content).unwrap_or_default();
+                let content = fs::read_to_string(config_path)?;
+                return Ok(toml::from_str(&content)?);
             }
         }
-        Self::default()
+        Ok(Self::default())
     }
 
-    pub fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn save(&self) -> Result<(), NotedError> {
         if let Some(config_path) = get_config_path() {
             let toml_string = toml::to_string_pretty(self)?;
             fs::write(config_path, toml_string)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,49 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum NotedError {
+    #[error(" Configuration file not found. Please run 'notedmd config --edit' to set it up.")]
+    ConfigNotFound,
+
+    #[error(" Failed to save configuration: {0}")]
+    ConfigSaveError(#[from] toml::ser::Error),
+
+    #[error(" Failed to read configuration: {0}")]
+    ConfigReadError(#[from] toml::de::Error),
+
+    #[error(" I/O error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error(" Network request failed: {0}")]
+    NetworkError(#[from] reqwest::Error),
+
+    #[error(" API key is invalid or missing. Please check your configuration.")]
+    InvalidApiKey,
+
+    #[error(" The AI provider returned an error: {0}")]
+    ApiError(String),
+
+    #[error(" Failed to decode API response: {0}")]
+    ResponseDecodeError(String),
+
+    #[error(" Could not determine the file name for the path: {0}")]
+    FileNameError(String),
+
+    #[error(" File type not supported: {0}")]
+    UnsupportedFileType(String),
+
+    #[error(" Ollama is not configured properly. Please run 'notedmd config --edit' to set it up.")]
+    OllamaNotConfigured,
+
+    #[error(" Gemini is not configured properly. Please run 'notedmd config --edit' to set it up.")]
+    GeminiNotConfigured,
+
+    #[error(" Claude is not configured properly. Please run 'notedmd config --edit' to set it up.")]
+    ClaudeNotConfigured,
+
+    #[error(" No active provider. Please run 'notedmd config --edit' to set a provider.")]
+    NoActiveProvider,
+
+    #[error(" Dialoguer error: {0}")]
+    DialoguerError(#[from] dialoguer::Error),
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,16 +223,44 @@ async fn main() {
                                 {
                                     Ok(key) => {
                                         config.active_provider = Some("claude".to_string());
-                                        let model = Input::with_theme(&ColorfulTheme::default())
-                                            .with_prompt("Claude model")
-                                            .default("claude-3-opus-20240229".to_string())
-                                            .interact_text()
-                                            .unwrap();
+                                        let anthropic_models = vec![
+                                            "    claude-opus-4-20250514",
+                                            "    claude-sonnet-4-20250514",
+                                            "    claude-3-7-sonnet-20250219",
+                                            "    claude-3-5-haiku-20241022",
+                                            "    claude-3-5-sonnet-20241022",
+                                            "    other",
+                                        ];
+                                        let selected_model =
+                                            Select::with_theme(&ColorfulTheme::default())
+                                                .with_prompt("Choose your Claude model:")
+                                                .items(&anthropic_models)
+                                                .default(0)
+                                                .interact()
+                                                .unwrap();
 
-                                        config.claude = Some(ClaudeConfig {
-                                            api_key: key.clone(),
-                                            model: model,
-                                        });
+                                        if selected_model == &anthropic_models.len() - 1 {
+                                            let other_model =
+                                                Input::with_theme(&ColorfulTheme::default())
+                                                    .with_prompt(
+                                                        "Enter the custom model name (e.g., claude-3-sonnet-20240229)",
+                                                    )
+                                                    .interact()
+                                                    .unwrap();
+
+                                            config.claude = Some(ClaudeConfig {
+                                                api_key: key.clone(),
+                                                model: other_model,
+                                            });
+                                        } else {
+                                            config.claude = Some(ClaudeConfig {
+                                                api_key: key.clone(),
+                                                model: anthropic_models[selected_model]
+                                                    .trim()
+                                                    .to_string(),
+                                            });
+                                        }
+
                                         let _save = match config.save() {
                                             Ok(()) => {
                                                 println!("{}", "Config saved successfully.".green())

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,3 +1,4 @@
+use crate::Config;
 use colored::Colorize;
 
 pub fn ascii_art() {
@@ -18,4 +19,46 @@ pub fn ascii_art() {
         "{}",
         "-------------------------------------------------".dimmed()
     );
+}
+
+pub fn print_clean_config(config: Config) {
+    println!("{}", "noted.md Configuration".bold());
+    println!("-------------------------");
+
+    if let Some(provider) = config.active_provider {
+        println!("Active Provider: {}", provider.green());
+    } else {
+        println!("Active Provider: {}", "Not Set".yellow());
+    }
+
+    println!("{}", "Gemini".bold());
+    if let Some(gemini_config) = config.gemini {
+        let api_key = format!(
+            "{:.3}***************** (hidden for security)",
+            gemini_config.api_key
+        );
+        println!("  API Key: {}", api_key);
+    } else {
+        println!("  (Not Configured)");
+    }
+
+    println!("{}", "Claude".bold());
+    if let Some(claude_config) = config.claude {
+        let api_key = format!(
+            "{:.3}***************** (hidden for security)",
+            claude_config.api_key
+        );
+        println!("  API Key: {}", api_key);
+        println!("  Model:   {}", claude_config.model);
+    } else {
+        println!("  (Not Configured)");
+    }
+
+    println!("{}", "Ollama".bold());
+    if let Some(ollama_config) = config.ollama {
+        println!("  URL:     {}", ollama_config.url);
+        println!("  Model:   {}", ollama_config.model);
+    } else {
+        println!("  (Not Configured)");
+    }
 }


### PR DESCRIPTION
- Fixes #1 

### Added
- Added `--show`, `--edit`, and `--set-provider` subcommands to the `config` command for better configuration management.

### Changed
- Updated the Claude model selection from a text input to a selection menu to improve user experience and prevent typos.

### Fixed
- Resolved an issue where API errors in successful (`200 OK`) responses were ignored, preventing silent failures.
- Corrected a bug where configuring the Ollama provider would erase all other existing provider settings.
